### PR TITLE
Fixes an example value which causes a unit test failure + uses the latest RAML parser (1.3.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.macrulez.utils</groupId>
     <artifactId>raml2swagger-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <name>RAML 2 Swagger Converter</name>
 
     <scm>

--- a/raml2swagger-app/pom.xml
+++ b/raml2swagger-app/pom.xml
@@ -8,14 +8,14 @@
     <parent>
         <groupId>org.macrulez.utils</groupId>
         <artifactId>raml2swagger-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.macrulez.utils</groupId>
             <artifactId>raml2swagger-lib</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.1-SNAPSHOT</version>
         </dependency>
 
         <!-- Logging -->

--- a/raml2swagger-lib/pom.xml
+++ b/raml2swagger-lib/pom.xml
@@ -33,24 +33,9 @@
             <version>1.9.3</version>
         </dependency>
         <dependency>
-            <groupId>com.mulesoft.jaxrs.raml.generator</groupId>
+            <groupId>org.raml</groupId>
             <artifactId>com.mulesoft.jaxrs.raml.generator</artifactId>
-            <version>1.3.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jlibs</groupId>
-                    <artifactId>jlibs-xml</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.9</version>
+            <version>1.3.4</version>
         </dependency>
 
         <!-- Logging -->
@@ -81,12 +66,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>MuleSoft</id>
-            <url>https://repository-master.mulesoft.org/nexus/content/repositories/releases</url>
-        </repository>
-    </repositories>
 
 </project>

--- a/raml2swagger-lib/pom.xml
+++ b/raml2swagger-lib/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.macrulez.utils</groupId>
         <artifactId>raml2swagger-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -36,6 +36,12 @@
             <groupId>org.raml</groupId>
             <artifactId>com.mulesoft.jaxrs.raml.generator</artifactId>
             <version>1.3.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Logging -->

--- a/raml2swagger-lib/src/test/resources/product-api.raml
+++ b/raml2swagger-lib/src/test/resources/product-api.raml
@@ -17,7 +17,7 @@ documentation:
       responses:
         200:
           body:
-            example: lol
+            example: {"example":"lol"}
   /clear:
     get:
       description: Clear cache entries
@@ -34,7 +34,7 @@ documentation:
       responses:
         200:
           body:
-            example: lol
+            example: {"example":"lol"}
 
 /:
   get:


### PR DESCRIPTION
- Updated RAML parser from 1.3.2 to 1.3.4
- Uses maven central release of the dependency instead of mulesoft's custom repository
- Fixes an error in the test RAML file which causes unit test (correctly) to fail
